### PR TITLE
Use quotes when testing $CC

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -90,7 +90,7 @@ dnl Call this gnulib macro right after a working C Compiler is found
 gl_EARLY
 
 dnl echo "CC = $CC"
-AS_IF([test x$CC = xgcc],
+AS_IF([test "x$CC" = xgcc],
       [AM_CONDITIONAL([COMPILER_IS_GCC],[true])],
       [AM_CONDITIONAL([COMPILER_IS_GCC],[false])])
 


### PR DESCRIPTION
This avoids the error "test: too many arguments" appearing in the
configure output if CC contains multiple words, such as "ccache cc".